### PR TITLE
解决部分用户telegram id 可能是int类型引起的报错

### DIFF
--- a/lib/features/panel/v2board/models/user_info_model.dart
+++ b/lib/features/panel/v2board/models/user_info_model.dart
@@ -12,7 +12,7 @@ class UserInfo {
   final int planId;
   final double? discount;
   final double? commissionRate;
-  final String? telegramId;
+  final Object? telegramId;
   final String uuid;
   final String avatarUrl;
 


### PR DESCRIPTION
不太确定telegram id 是不是所有人都是int，项目中暂时没有用到这字段，暂时先用Object